### PR TITLE
feat: Remove streaming loader from ChatMessage component

### DIFF
--- a/src/lib/components/Chatbot/ChatMessage.svelte
+++ b/src/lib/components/Chatbot/ChatMessage.svelte
@@ -134,7 +134,7 @@
 				{/if}
 			{/if}
 		{/each}
-		{#if loading === 'fetching' || loading === 'streaming'}
+		{#if loading === 'fetching'}
 			<div class="p-6 px-4">
 				<img
 					src="/chatloader.png"


### PR DESCRIPTION
The code changes remove the condition to show the loader when streaming data in the ChatMessage component. The loader will now only be displayed when fetching data.

Ref: #123